### PR TITLE
Tag releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,10 @@ name: CI
 
 on:
   push:
+    branches:
+      - '**'
+    tags:
+      - '*'
   pull_request:
 
 jobs:
@@ -21,9 +25,11 @@ jobs:
       - name: Build
         run: go build ./cmd/...
   release:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     needs: lint-test-build
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    if: github.ref_type == 'tag'
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -35,14 +41,11 @@ jobs:
           GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o dist/meshgo-linux-amd64 ./cmd/meshgo
           GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go build -o dist/meshgo-windows-amd64.exe ./cmd/meshgo
           GOOS=darwin GOARCH=amd64 CGO_ENABLED=0 go build -o dist/meshgo-darwin-amd64 ./cmd/meshgo
-      - name: Set release name
-        id: vars
-        run: echo "name=$(date +%F)-${GITHUB_SHA::8}" >> $GITHUB_OUTPUT
       - name: Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ github.sha }}
-          name: ${{ steps.vars.outputs.name }}
+          tag_name: ${{ github.ref_name }}
+          name: ${{ github.ref_name }}
           files: dist/*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- trigger workflow on tag pushes and gate release job on tag refs
- use pushed tag name for release

## Testing
- `go test -v ./...`


------
https://chatgpt.com/codex/tasks/task_b_689d150d2e448329a8a4f76e07338c49