### PR TITLE
Fix startup without tray and add logging

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"log/slog"
 	"time"
 
 	"meshgo/domain"
@@ -41,8 +42,13 @@ func New(r Radio, ms *storage.MessageStore, ns *storage.NodeStore, cs *storage.C
 // Run starts the radio client with the given transport and processes events
 // until the context is cancelled.
 func (a *App) Run(ctx context.Context, t transport.Transport) error {
+	slog.Info("app starting", "endpoint", t.Endpoint())
 	go a.eventLoop(ctx)
-	return a.Radio.Start(ctx, t)
+	err := a.Radio.Start(ctx, t)
+	if err != nil {
+		slog.Error("radio stopped", "err", err)
+	}
+	return err
 }
 
 // SendText sends a text message via the radio client and persists it to the store.
@@ -122,6 +128,7 @@ func (a *App) handlePacket(ctx context.Context, pkt []byte) {
 		IsUnread:  true,
 	}
 	if err := a.Messages.InsertMessage(ctx, m); err == nil {
+		slog.Info("packet received", "chat", m.ChatID, "text", m.Text)
 		if a.Chats != nil {
 			_ = a.Chats.UpsertChat(ctx, &domain.Chat{ID: m.ChatID, Title: m.ChatID, LastMessageTS: m.Timestamp.Unix()})
 		}
@@ -139,6 +146,7 @@ func (a *App) handleNode(ctx context.Context, n *domain.Node) {
 	}
 	n.Signal = domain.ComputeSignalQuality(n.RSSI, n.SNR)
 	_ = a.Nodes.UpsertNode(ctx, n)
+	slog.Info("node event", "id", n.ID, "short", n.ShortName, "signal", n.Signal)
 	a.events <- Event{Type: EventNode, Node: n}
 }
 

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -53,7 +53,10 @@ func (n *stubNotifier) NotifyNewMessage(chatID, title, body string, ts time.Time
 
 func (n *stubNotifier) SetEnabled(e bool) { n.enabled = e }
 
-type stubTray struct{ unread bool }
+type stubTray struct {
+	unread bool
+	ready  chan struct{}
+}
 
 func (t *stubTray) SetUnread(u bool)                    { t.unread = u }
 func (t *stubTray) OnShowHide(fn func())                {}
@@ -61,6 +64,13 @@ func (t *stubTray) OnToggleNotifications(fn func(bool)) {}
 func (t *stubTray) OnExit(fn func())                    {}
 func (t *stubTray) Run()                                {}
 func (t *stubTray) Quit()                               {}
+func (t *stubTray) Ready() <-chan struct{} {
+	if t.ready == nil {
+		t.ready = make(chan struct{})
+		close(t.ready)
+	}
+	return t.ready
+}
 
 func TestAppStoresPacketsAndNotifies(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())

--- a/cmd/meshgo/main.go
+++ b/cmd/meshgo/main.go
@@ -69,21 +69,28 @@ func main() {
 	}
 	defer closer.Close()
 	slog.SetDefault(l)
+	slog.Info("starting meshgo", "log", logPath)
 
 	var t transport.Transport
 	switch settings.Connection.Type {
 	case "serial":
-		t = transport.NewSerial(settings.Connection.Serial.Port)
-	default:
+		if settings.Connection.Serial.Port != "" {
+			t = transport.NewSerial(settings.Connection.Serial.Port)
+			slog.Info("configured transport", "type", "serial", "endpoint", t.Endpoint())
+		} else {
+			slog.Info("serial port not configured; running offline")
+		}
+	case "tcp":
 		host := settings.Connection.IP.Host
-		if host == "" {
-			host = "localhost"
-		}
 		port := settings.Connection.IP.Port
-		if port == 0 {
-			port = 4403
+		if host != "" && port != 0 {
+			t = transport.NewTCP(net.JoinHostPort(host, strconv.Itoa(port)))
+			slog.Info("configured transport", "type", "tcp", "endpoint", t.Endpoint())
+		} else {
+			slog.Info("tcp endpoint not configured; running offline")
 		}
-		t = transport.NewTCP(net.JoinHostPort(host, strconv.Itoa(port)))
+	default:
+		slog.Info("no connection configured; running offline")
 	}
 
 	dbPath := filepath.Join(cfgDir, "meshgo.db")
@@ -199,36 +206,46 @@ func main() {
 	defer cancel()
 	a = app.New(rc, ms, ns, cs, chs, notifier, tr)
 
+	trDone := make(chan struct{})
 	go func() {
-		for ev := range a.Events() {
-			switch ev.Type {
-			case app.EventConnecting:
-				slog.Info("connecting")
-			case app.EventConnected:
-				slog.Info("connected")
-			case app.EventDisconnected:
-				slog.Info("disconnected", "err", ev.Err)
-			case app.EventRetrying:
-				slog.Info("retrying", "delay", ev.Delay)
-			case app.EventMessage:
-				if ev.Message != nil {
-					slog.Info("message", "chat", ev.Message.ChatID, "text", ev.Message.Text)
-				}
-			case app.EventNode:
-				if ev.Node != nil {
-					slog.Info("node", "id", ev.Node.ID, "short", ev.Node.ShortName, "signal", ev.Node.Signal)
+		tr.Run()
+		close(trDone)
+	}()
+	<-tr.Ready()
+
+	if t != nil {
+		go func() {
+			for ev := range a.Events() {
+				switch ev.Type {
+				case app.EventConnecting:
+					slog.Info("connecting")
+				case app.EventConnected:
+					slog.Info("connected")
+				case app.EventDisconnected:
+					slog.Info("disconnected", "err", ev.Err)
+				case app.EventRetrying:
+					slog.Info("retrying", "delay", ev.Delay)
+				case app.EventMessage:
+					if ev.Message != nil {
+						slog.Info("message", "chat", ev.Message.ChatID, "text", ev.Message.Text)
+					}
+				case app.EventNode:
+					if ev.Node != nil {
+						slog.Info("node", "id", ev.Node.ID, "short", ev.Node.ShortName, "signal", ev.Node.Signal)
+					}
 				}
 			}
-		}
-	}()
+		}()
 
-	go func() {
-		if err := a.Run(ctx, t); err != nil && !errors.Is(err, context.Canceled) {
-			slog.Error("run app", "err", err)
-		}
-		cancel()
-		tr.Quit()
-	}()
+		go func() {
+			if err := a.Run(ctx, t); err != nil && !errors.Is(err, context.Canceled) {
+				slog.Error("run app", "err", err)
+			}
+			cancel()
+		}()
+	}
 
-	tr.Run()
+	<-ctx.Done()
+	tr.Quit()
+	<-trDone
 }

--- a/radio/client.go
+++ b/radio/client.go
@@ -3,6 +3,7 @@ package radio
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"math/rand"
 	"sync"
 	"time"
@@ -57,7 +58,9 @@ func (c *Client) Start(ctx context.Context, t transport.Transport) error {
 		default:
 		}
 		c.events <- Event{Type: EventConnecting}
+		slog.Info("radio connecting", "endpoint", t.Endpoint())
 		if err := t.Connect(ctx); err != nil {
+			slog.Error("radio connect failed", "err", err)
 			c.events <- Event{Type: EventDisconnected, Err: err}
 			delay := jitterDuration(backoff, c.cfg.Jitter)
 			c.events <- Event{Type: EventRetrying, Delay: delay}
@@ -67,10 +70,12 @@ func (c *Client) Start(ctx context.Context, t transport.Transport) error {
 			backoff = nextBackoff(backoff, c.cfg)
 			continue
 		}
+		slog.Info("radio connected", "endpoint", t.Endpoint())
 		c.events <- Event{Type: EventConnected}
 		c.setTransport(t)
 		start := time.Now()
 		if err := c.readLoop(ctx, t); err != nil {
+			slog.Error("radio read loop ended", "err", err)
 			c.events <- Event{Type: EventDisconnected, Err: err}
 		}
 		c.setTransport(nil)
@@ -92,6 +97,7 @@ func (c *Client) readLoop(ctx context.Context, t transport.Transport) error {
 	for {
 		pkt, err := t.ReadPacket(ctx)
 		if err != nil {
+			slog.Error("read packet failed", "err", err)
 			return err
 		}
 		c.events <- Event{Type: EventPacket, Packet: pkt}

--- a/transport/serial.go
+++ b/transport/serial.go
@@ -3,6 +3,7 @@ package transport
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"time"
 
 	"go.bug.st/serial"
@@ -23,9 +24,11 @@ func NewSerial(name string) *SerialTransport {
 
 // Connect opens the serial port with the configured baud rate.
 func (s *SerialTransport) Connect(ctx context.Context) error {
+	slog.Info("serial open", "port", s.name, "baud", s.baud)
 	mode := &serial.Mode{BaudRate: s.baud}
 	p, err := serial.Open(s.name, mode)
 	if err != nil {
+		slog.Error("serial open failed", "port", s.name, "err", err)
 		return err
 	}
 	s.port = p
@@ -35,8 +38,12 @@ func (s *SerialTransport) Connect(ctx context.Context) error {
 // Close closes the serial port if it is open.
 func (s *SerialTransport) Close() error {
 	if s.port != nil {
+		slog.Info("serial close", "port", s.name)
 		err := s.port.Close()
 		s.port = nil
+		if err != nil {
+			slog.Error("serial close error", "port", s.name, "err", err)
+		}
 		return err
 	}
 	return nil
@@ -53,6 +60,7 @@ func (s *SerialTransport) ReadPacket(ctx context.Context) ([]byte, error) {
 	buf := make([]byte, 1024)
 	n, err := s.port.Read(buf)
 	if err != nil {
+		slog.Error("serial read", "err", err)
 		return nil, err
 	}
 	return buf[:n], nil
@@ -69,6 +77,9 @@ func (s *SerialTransport) WritePacket(ctx context.Context, b []byte) error {
 		}
 	}
 	_, err := s.port.Write(b)
+	if err != nil {
+		slog.Error("serial write", "err", err)
+	}
 	return err
 }
 

--- a/transport/tcp.go
+++ b/transport/tcp.go
@@ -2,6 +2,7 @@ package transport
 
 import (
 	"context"
+	"log/slog"
 	"net"
 	"time"
 )
@@ -17,16 +18,24 @@ func NewTCP(addr string) *TCPTransport { return &TCPTransport{addr: addr} }
 
 // Connect dials the configured TCP endpoint.
 func (t *TCPTransport) Connect(ctx context.Context) error {
+	slog.Info("tcp connect", "addr", t.addr)
 	var err error
 	t.conn, err = (&net.Dialer{}).DialContext(ctx, "tcp", t.addr)
+	if err != nil {
+		slog.Error("tcp connect failed", "addr", t.addr, "err", err)
+	}
 	return err
 }
 
 // Close closes the underlying connection if open.
 func (t *TCPTransport) Close() error {
 	if t.conn != nil {
+		slog.Info("tcp close", "addr", t.addr)
 		err := t.conn.Close()
 		t.conn = nil
+		if err != nil {
+			slog.Error("tcp close error", "addr", t.addr, "err", err)
+		}
 		return err
 	}
 	return nil
@@ -42,6 +51,7 @@ func (t *TCPTransport) ReadPacket(ctx context.Context) ([]byte, error) {
 	buf := make([]byte, 1024)
 	n, err := t.conn.Read(buf)
 	if err != nil {
+		slog.Error("tcp read", "err", err)
 		return nil, err
 	}
 	return buf[:n], nil
@@ -54,6 +64,9 @@ func (t *TCPTransport) WritePacket(ctx context.Context, b []byte) error {
 	}
 	_ = t.conn.SetWriteDeadline(deadlineFromContext(ctx))
 	_, err := t.conn.Write(b)
+	if err != nil {
+		slog.Error("tcp write", "err", err)
+	}
 	return err
 }
 

--- a/tray/systray.go
+++ b/tray/systray.go
@@ -4,6 +4,7 @@ package tray
 
 import (
 	"encoding/base64"
+	"log/slog"
 
 	"github.com/getlantern/systray"
 )
@@ -29,12 +30,13 @@ type Systray struct {
 	toggle        func(bool)
 	exit          func()
 	notifications bool
+	ready         chan struct{}
 }
 
 // NewSystray creates a new Systray. The enabled parameter sets the initial
 // notifications state and checkbox.
 func NewSystray(enabled bool) Tray {
-	return &Systray{notifications: enabled}
+	return &Systray{notifications: enabled, ready: make(chan struct{})}
 }
 
 // SetUnread switches the icon depending on unread status.
@@ -57,6 +59,7 @@ func (s *Systray) OnExit(fn func()) { s.exit = fn }
 
 // Run starts the tray event loop and blocks until the tray is closed.
 func (s *Systray) Run() {
+	slog.Info("starting systray")
 	systray.Run(s.onReady, s.onExit)
 }
 
@@ -66,6 +69,8 @@ func (s *Systray) Quit() {
 }
 
 func (s *Systray) onReady() {
+	slog.Info("systray ready")
+	close(s.ready)
 	systray.SetIcon(iconDefault)
 	systray.SetTooltip("meshgo")
 
@@ -106,4 +111,9 @@ func (s *Systray) onReady() {
 	}()
 }
 
-func (s *Systray) onExit() {}
+func (s *Systray) onExit() {
+	slog.Info("systray exit")
+}
+
+// Ready returns a channel that's closed when the systray icon is displayed.
+func (s *Systray) Ready() <-chan struct{} { return s.ready }

--- a/tray/systray_stub.go
+++ b/tray/systray_stub.go
@@ -2,7 +2,10 @@
 
 package tray
 
+import "log/slog"
+
 // NewSystray returns a no-op Tray when CGO is disabled.
 func NewSystray(enabled bool) Tray {
-	return &Noop{}
+	slog.Info("systray unavailable; running without GUI")
+	return &Noop{quit: make(chan struct{}), ready: make(chan struct{})}
 }

--- a/tray/tray.go
+++ b/tray/tray.go
@@ -1,5 +1,7 @@
 package tray
 
+import "log/slog"
+
 // Tray controls the application tray icon state and routes user interactions.
 type Tray interface {
 	// SetUnread toggles the unread indicator.
@@ -14,6 +16,8 @@ type Tray interface {
 	Run()
 	// Quit requests the tray event loop to exit.
 	Quit()
+	// Ready returns a channel that's closed when the tray is ready.
+	Ready() <-chan struct{}
 }
 
 // Noop implements Tray with no side effects.
@@ -21,6 +25,8 @@ type Noop struct {
 	showHide func()
 	toggle   func(bool)
 	exit     func()
+	quit     chan struct{}
+	ready    chan struct{}
 }
 
 func (n *Noop) SetUnread(bool) {}
@@ -31,6 +37,45 @@ func (n *Noop) OnToggleNotifications(fn func(bool)) { n.toggle = fn }
 
 func (n *Noop) OnExit(fn func()) { n.exit = fn }
 
-func (n *Noop) Run() {}
+// Run blocks until Quit is called.
+func (n *Noop) Run() {
+	if n.quit == nil {
+		n.quit = make(chan struct{})
+	}
+	if n.ready == nil {
+		n.ready = make(chan struct{})
+	}
+	select {
+	case <-n.ready:
+		// already closed
+	default:
+		close(n.ready)
+	}
+	slog.Info("tray disabled; running without system tray")
+	<-n.quit
+}
 
-func (n *Noop) Quit() {}
+// Quit unblocks Run and calls the exit callback if set.
+func (n *Noop) Quit() {
+	if n.quit != nil {
+		select {
+		case <-n.quit:
+			// already closed
+		default:
+			close(n.quit)
+		}
+	}
+	if n.exit != nil {
+		n.exit()
+	}
+	slog.Info("tray quit")
+}
+
+// Ready returns a channel that's closed immediately as the noop tray is ready at startup.
+func (n *Noop) Ready() <-chan struct{} {
+	if n.ready == nil {
+		n.ready = make(chan struct{})
+		close(n.ready)
+	}
+	return n.ready
+}

--- a/tray/tray_test.go
+++ b/tray/tray_test.go
@@ -1,9 +1,12 @@
 package tray
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
 
 func TestNoopCallbacks(t *testing.T) {
-	n := &Noop{}
+	n := &Noop{quit: make(chan struct{})}
 	calledShow := false
 	n.OnShowHide(func() { calledShow = true })
 	if n.showHide == nil {
@@ -29,12 +32,21 @@ func TestNoopCallbacks(t *testing.T) {
 	if n.exit == nil {
 		t.Fatalf("exit callback not set")
 	}
-	n.exit()
+
+	// Run should close Ready, block until Quit is called and trigger exit callback.
+	done := make(chan struct{})
+	go func() {
+		n.Run()
+		close(done)
+	}()
+	select {
+	case <-n.Ready():
+	case <-time.After(time.Second):
+		t.Fatalf("Ready not closed")
+	}
+	n.Quit()
+	<-done
 	if !exited {
 		t.Fatalf("exit callback not invoked")
 	}
-
-	// Run and Quit should be no-ops
-	n.Run()
-	n.Quit()
 }


### PR DESCRIPTION
## Summary
- prevent premature exit when system tray is unavailable by blocking noop tray
- add structured logging across startup, transports, radio client, and app
- fix blocking test by running noop tray asynchronously and verifying exit callback
- wait for tray to render before connecting and allow running with no transport configured

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_689df1c095b08329a50d7a334ff872cc