### PR TITLE
Delay radio connect until tray ready

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -53,7 +53,9 @@ func (a *App) Run(ctx context.Context, t transport.Transport) error {
 
 // SendText sends a text message via the radio client and persists it to the store.
 func (a *App) SendText(ctx context.Context, chatID string, toNode uint32, text string) error {
+	slog.Info("app send text", "chat", chatID, "to", toNode)
 	if err := a.Radio.SendText(ctx, chatID, toNode, text); err != nil {
+		slog.Error("app send text failed", "err", err)
 		return err
 	}
 	if a.Messages != nil {
@@ -63,6 +65,7 @@ func (a *App) SendText(ctx context.Context, chatID string, toNode uint32, text s
 			Timestamp: time.Now(),
 		}
 		if err := a.Messages.InsertMessage(ctx, m); err != nil {
+			slog.Error("store message", "err", err)
 			return err
 		}
 		if a.Chats != nil {
@@ -90,7 +93,11 @@ func (a *App) SendTraceroute(ctx context.Context, node uint32) error {
 }
 
 func (a *App) eventLoop(ctx context.Context) {
-	defer close(a.events)
+	slog.Info("event loop started")
+	defer func() {
+		slog.Info("event loop stopped")
+		close(a.events)
+	}()
 	for {
 		select {
 		case <-ctx.Done():

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -59,6 +59,7 @@ func (t *stubTray) SetUnread(u bool)                    { t.unread = u }
 func (t *stubTray) OnShowHide(fn func())                {}
 func (t *stubTray) OnToggleNotifications(fn func(bool)) {}
 func (t *stubTray) OnExit(fn func())                    {}
+func (t *stubTray) OnReady(fn func())                   {}
 func (t *stubTray) Run()                                {}
 func (t *stubTray) Quit()                               {}
 

--- a/cmd/meshgo/main.go
+++ b/cmd/meshgo/main.go
@@ -248,9 +248,12 @@ func main() {
 	}()
 
 	tr.OnReady(func() {
+		slog.Info("tray ready")
 		if !hasConn {
+			slog.Info("no connection configured; radio not started")
 			return
 		}
+		slog.Info("starting radio", "endpoint", t.Endpoint())
 		go func() {
 			if err := a.Run(ctx, t); err != nil && !errors.Is(err, context.Canceled) {
 				slog.Error("run app", "err", err)

--- a/cmd/meshgo/main.go
+++ b/cmd/meshgo/main.go
@@ -71,22 +71,36 @@ func main() {
 	slog.SetDefault(l)
 	slog.Info("starting meshgo", "log", logPath)
 
-	var t transport.Transport
+	var (
+		t       transport.Transport
+		hasConn bool
+	)
 	switch settings.Connection.Type {
 	case "serial":
-		t = transport.NewSerial(settings.Connection.Serial.Port)
-		slog.Info("configured transport", "type", "serial", "endpoint", t.Endpoint())
+		if settings.Connection.Serial.Port != "" {
+			t = transport.NewSerial(settings.Connection.Serial.Port)
+			slog.Info("configured transport", "type", "serial", "endpoint", t.Endpoint())
+			hasConn = true
+		}
+	case "tcp":
+		fallthrough
 	default:
 		host := settings.Connection.IP.Host
-		if host == "" {
-			host = "localhost"
-		}
 		port := settings.Connection.IP.Port
-		if port == 0 {
-			port = 4403
+		if host != "" || port != 0 || settings.Connection.Type == "tcp" {
+			if host == "" {
+				host = "localhost"
+			}
+			if port == 0 {
+				port = 4403
+			}
+			t = transport.NewTCP(net.JoinHostPort(host, strconv.Itoa(port)))
+			slog.Info("configured transport", "type", "tcp", "endpoint", t.Endpoint())
+			hasConn = true
 		}
-		t = transport.NewTCP(net.JoinHostPort(host, strconv.Itoa(port)))
-		slog.Info("configured transport", "type", "tcp", "endpoint", t.Endpoint())
+	}
+	if !hasConn {
+		slog.Info("no connection configured; radio disabled")
 	}
 
 	dbPath := filepath.Join(cfgDir, "meshgo.db")
@@ -203,35 +217,48 @@ func main() {
 	a = app.New(rc, ms, ns, cs, chs, notifier, tr)
 
 	go func() {
-		for ev := range a.Events() {
-			switch ev.Type {
-			case app.EventConnecting:
-				slog.Info("connecting")
-			case app.EventConnected:
-				slog.Info("connected")
-			case app.EventDisconnected:
-				slog.Info("disconnected", "err", ev.Err)
-			case app.EventRetrying:
-				slog.Info("retrying", "delay", ev.Delay)
-			case app.EventMessage:
-				if ev.Message != nil {
-					slog.Info("message", "chat", ev.Message.ChatID, "text", ev.Message.Text)
+		for {
+			select {
+			case ev, ok := <-a.Events():
+				if !ok {
+					return
 				}
-			case app.EventNode:
-				if ev.Node != nil {
-					slog.Info("node", "id", ev.Node.ID, "short", ev.Node.ShortName, "signal", ev.Node.Signal)
+				switch ev.Type {
+				case app.EventConnecting:
+					slog.Info("connecting")
+				case app.EventConnected:
+					slog.Info("connected")
+				case app.EventDisconnected:
+					slog.Info("disconnected", "err", ev.Err)
+				case app.EventRetrying:
+					slog.Info("retrying", "delay", ev.Delay)
+				case app.EventMessage:
+					if ev.Message != nil {
+						slog.Info("message", "chat", ev.Message.ChatID, "text", ev.Message.Text)
+					}
+				case app.EventNode:
+					if ev.Node != nil {
+						slog.Info("node", "id", ev.Node.ID, "short", ev.Node.ShortName, "signal", ev.Node.Signal)
+					}
 				}
+			case <-ctx.Done():
+				return
 			}
 		}
 	}()
 
-	go func() {
-		if err := a.Run(ctx, t); err != nil && !errors.Is(err, context.Canceled) {
-			slog.Error("run app", "err", err)
+	tr.OnReady(func() {
+		if !hasConn {
+			return
 		}
-		cancel()
-		tr.Quit()
-	}()
+		go func() {
+			if err := a.Run(ctx, t); err != nil && !errors.Is(err, context.Canceled) {
+				slog.Error("run app", "err", err)
+			}
+			cancel()
+			tr.Quit()
+		}()
+	})
 
 	tr.Run()
 }

--- a/cmd/meshgo/main.go
+++ b/cmd/meshgo/main.go
@@ -42,6 +42,7 @@ func main() {
 		slog.Error("create config dir", "err", err)
 		os.Exit(1)
 	}
+	slog.Info("using config dir", "path", cfgDir)
 	settingsPath := filepath.Join(cfgDir, "config.json")
 
 	settings, err := storage.LoadSettings(settingsPath)
@@ -53,7 +54,11 @@ func main() {
 		settings = &storage.Settings{}
 		if err := storage.SaveSettings(settingsPath, settings); err != nil {
 			slog.Error("save default settings", "err", err)
+		} else {
+			slog.Info("wrote default settings", "path", settingsPath)
 		}
+	} else {
+		slog.Info("loaded settings", "path", settingsPath)
 	}
 
 	logDir := filepath.Join(cfgDir, "logs")
@@ -61,6 +66,7 @@ func main() {
 		slog.Error("create log dir", "err", err)
 		os.Exit(1)
 	}
+	slog.Info("using log dir", "path", logDir)
 	logPath := filepath.Join(logDir, "meshgo.log")
 	l, closer, err := logger.New(logPath, settings.Logging.Enabled)
 	if err != nil {
@@ -109,44 +115,52 @@ func main() {
 		slog.Error("open message store", "err", err)
 		os.Exit(1)
 	}
+	slog.Info("opened message store", "db", dbPath)
 	defer ms.Close()
 	if err := ms.Init(ctx); err != nil {
 		slog.Error("init message store", "err", err)
 		os.Exit(1)
 	}
+	slog.Info("initialized message store")
 
 	ns, err := storage.OpenNodeStore(dbPath)
 	if err != nil {
 		slog.Error("open node store", "err", err)
 		os.Exit(1)
 	}
+	slog.Info("opened node store")
 	defer ns.Close()
 	if err := ns.Init(ctx); err != nil {
 		slog.Error("init node store", "err", err)
 		os.Exit(1)
 	}
+	slog.Info("initialized node store")
 
 	cs, err := storage.OpenChatStore(dbPath)
 	if err != nil {
 		slog.Error("open chat store", "err", err)
 		os.Exit(1)
 	}
+	slog.Info("opened chat store")
 	defer cs.Close()
 	if err := cs.Init(ctx); err != nil {
 		slog.Error("init chat store", "err", err)
 		os.Exit(1)
 	}
+	slog.Info("initialized chat store")
 
 	chs, err := storage.OpenChannelStore(dbPath)
 	if err != nil {
 		slog.Error("open channel store", "err", err)
 		os.Exit(1)
 	}
+	slog.Info("opened channel store")
 	defer chs.Close()
 	if err := chs.Init(ctx); err != nil {
 		slog.Error("init channel store", "err", err)
 		os.Exit(1)
 	}
+	slog.Info("initialized channel store")
 
 	a := app.New(nil, ms, ns, cs, chs, nil, nil)
 	if *listChats {

--- a/radio/client.go
+++ b/radio/client.go
@@ -110,9 +110,16 @@ func (c *Client) SendText(ctx context.Context, chatID string, toNode uint32, tex
 	t := c.t
 	c.tMu.RUnlock()
 	if t == nil {
-		return errors.New("not connected")
+		err := errors.New("not connected")
+		slog.Error("radio send text failed", "err", err)
+		return err
 	}
-	return t.WritePacket(ctx, []byte(text))
+	slog.Info("radio send text", "chat", chatID, "to", toNode)
+	if err := t.WritePacket(ctx, []byte(text)); err != nil {
+		slog.Error("radio send text failed", "err", err)
+		return err
+	}
+	return nil
 }
 
 // SendExchangeUserInfo requests user information from the specified node.
@@ -121,9 +128,16 @@ func (c *Client) SendExchangeUserInfo(ctx context.Context, node uint32) error {
 	t := c.t
 	c.tMu.RUnlock()
 	if t == nil {
-		return errors.New("not connected")
+		err := errors.New("not connected")
+		slog.Error("radio send userinfo failed", "err", err)
+		return err
 	}
-	return t.WritePacket(ctx, []byte("userinfo"))
+	slog.Info("radio send userinfo", "node", node)
+	if err := t.WritePacket(ctx, []byte("userinfo")); err != nil {
+		slog.Error("radio send userinfo failed", "err", err)
+		return err
+	}
+	return nil
 }
 
 // SendTraceroute requests a traceroute to the specified node.
@@ -132,9 +146,16 @@ func (c *Client) SendTraceroute(ctx context.Context, node uint32) error {
 	t := c.t
 	c.tMu.RUnlock()
 	if t == nil {
-		return errors.New("not connected")
+		err := errors.New("not connected")
+		slog.Error("radio send traceroute failed", "err", err)
+		return err
 	}
-	return t.WritePacket(ctx, []byte("traceroute"))
+	slog.Info("radio send traceroute", "node", node)
+	if err := t.WritePacket(ctx, []byte("traceroute")); err != nil {
+		slog.Error("radio send traceroute failed", "err", err)
+		return err
+	}
+	return nil
 }
 
 func (c *Client) setTransport(t transport.Transport) {

--- a/transport/serial.go
+++ b/transport/serial.go
@@ -32,6 +32,7 @@ func (s *SerialTransport) Connect(ctx context.Context) error {
 		return err
 	}
 	s.port = p
+	slog.Info("serial opened", "port", s.name)
 	return nil
 }
 

--- a/transport/tcp.go
+++ b/transport/tcp.go
@@ -23,8 +23,10 @@ func (t *TCPTransport) Connect(ctx context.Context) error {
 	t.conn, err = (&net.Dialer{}).DialContext(ctx, "tcp", t.addr)
 	if err != nil {
 		slog.Error("tcp connect failed", "addr", t.addr, "err", err)
+		return err
 	}
-	return err
+	slog.Info("tcp connected", "addr", t.addr)
+	return nil
 }
 
 // Close closes the underlying connection if open.

--- a/tray/systray.go
+++ b/tray/systray.go
@@ -30,6 +30,7 @@ type Systray struct {
 	toggle        func(bool)
 	exit          func()
 	notifications bool
+	ready         func()
 }
 
 // NewSystray creates a new Systray. The enabled parameter sets the initial
@@ -56,6 +57,9 @@ func (s *Systray) OnToggleNotifications(fn func(bool)) { s.toggle = fn }
 // OnExit registers a callback for exit requests.
 func (s *Systray) OnExit(fn func()) { s.exit = fn }
 
+// OnReady registers a callback invoked when the tray is ready.
+func (s *Systray) OnReady(fn func()) { s.ready = fn }
+
 // Run starts the tray event loop and blocks until the tray is closed.
 func (s *Systray) Run() {
 	slog.Info("starting systray")
@@ -71,6 +75,9 @@ func (s *Systray) onReady() {
 	slog.Info("systray ready")
 	systray.SetIcon(iconDefault)
 	systray.SetTooltip("meshgo")
+	if s.ready != nil {
+		s.ready()
+	}
 
 	mShow := systray.AddMenuItem("Show/Hide", "Show or hide the window")
 	mToggle := systray.AddMenuItemCheckbox("Enable notifications", "Toggle notifications", s.notifications)

--- a/tray/systray_test.go
+++ b/tray/systray_test.go
@@ -30,6 +30,16 @@ func TestSystrayCallbacks(t *testing.T) {
 		t.Fatalf("toggle callback not invoked")
 	}
 
+	ready := false
+	s.OnReady(func() { ready = true })
+	if s.ready == nil {
+		t.Fatalf("ready callback not set")
+	}
+	s.ready()
+	if !ready {
+		t.Fatalf("ready callback not invoked")
+	}
+
 	exited := false
 	s.OnExit(func() { exited = true })
 	if s.exit == nil {

--- a/tray/tray.go
+++ b/tray/tray.go
@@ -12,6 +12,8 @@ type Tray interface {
 	OnToggleNotifications(fn func(enabled bool))
 	// OnExit registers a callback for exit requests.
 	OnExit(fn func())
+	// OnReady registers a callback invoked when the tray is ready.
+	OnReady(fn func())
 	// Run starts the tray event loop and blocks until the tray is closed.
 	Run()
 	// Quit requests the tray event loop to exit.
@@ -23,6 +25,7 @@ type Noop struct {
 	showHide func()
 	toggle   func(bool)
 	exit     func()
+	ready    func()
 	quit     chan struct{}
 }
 
@@ -34,12 +37,17 @@ func (n *Noop) OnToggleNotifications(fn func(bool)) { n.toggle = fn }
 
 func (n *Noop) OnExit(fn func()) { n.exit = fn }
 
+func (n *Noop) OnReady(fn func()) { n.ready = fn }
+
 // Run blocks until Quit is called.
 func (n *Noop) Run() {
 	if n.quit == nil {
 		n.quit = make(chan struct{})
 	}
 	slog.Info("tray disabled; running without system tray")
+	if n.ready != nil {
+		n.ready()
+	}
 	<-n.quit
 }
 

--- a/tray/tray.go
+++ b/tray/tray.go
@@ -46,6 +46,7 @@ func (n *Noop) Run() {
 	}
 	slog.Info("tray disabled; running without system tray")
 	if n.ready != nil {
+		slog.Info("tray ready")
 		n.ready()
 	}
 	<-n.quit

--- a/tray/tray_test.go
+++ b/tray/tray_test.go
@@ -29,13 +29,19 @@ func TestNoopCallbacks(t *testing.T) {
 	if n.exit == nil {
 		t.Fatalf("exit callback not set")
 	}
+	readyCh := make(chan struct{})
+	n.OnReady(func() { close(readyCh) })
+	if n.ready == nil {
+		t.Fatalf("ready callback not set")
+	}
 
-	// Run should block until Quit is called and trigger the exit callback.
+	// Run should block until Quit is called and trigger callbacks.
 	done := make(chan struct{})
 	go func() {
 		n.Run()
 		close(done)
 	}()
+	<-readyCh
 	n.Quit()
 	<-done
 	if !exited {


### PR DESCRIPTION
## Summary
- add OnReady callback to tray interface and implementations
- wait for tray readiness before starting radio connection
- skip connection attempts when no endpoint configured

## Testing
- `CGO_ENABLED=0 /root/.local/share/mise/installs/go/1.24.3/bin/go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_689e3ec23b48832985c33be04acc966d